### PR TITLE
insert MouseUp-function to stop interval for moving when timeout

### DIFF
--- a/newapp.js
+++ b/newapp.js
@@ -84,6 +84,7 @@ function Drop() {
   if (game_state == 1) {
     return;
   }
+  MouseUp();
   clearInterval(count_id);
   game_state = 1;
   Body.setStatic(current, false);


### PR DESCRIPTION
LEFT/RIGHTを押しっぱなしの状態で時間切れを迎えると落下後も横に動いてしまうのでDrop関数の中でMouseUp関数を呼んでIntervalを解除するようにしました。